### PR TITLE
Added 'PENDING' status check when videos come from jsonobject

### DIFF
--- a/bc-catalog-objects/javadoc/com/brightcove/commons/catalog/objects/Video.html
+++ b/bc-catalog-objects/javadoc/com/brightcove/commons/catalog/objects/Video.html
@@ -1694,7 +1694,7 @@ public <A HREF="../../../../../com/brightcove/commons/catalog/objects/enumeratio
           Read only?:    no<br/>
           Description:   An
                          <a href="http://docs.brightcove.com/en/media/index.html#ItemStateEnum">ItemStateEnum</a>.
-                         One of the properties: ACTIVE, INACTIVE, or
+                         One of the properties: ACTIVE, INACTIVE, PENDING, or
                          DELETED. You can set this property only to
                          ACTIVE or INACTIVE; you cannot delete a video
                          by setting its itemState to DELETED.
@@ -1724,7 +1724,7 @@ public void <B>setItemState</B>(<A HREF="../../../../../com/brightcove/commons/c
           Read only?:    no<br/>
           Description:   An
                          <a href="http://docs.brightcove.com/en/media/index.html#ItemStateEnum">ItemStateEnum</a>.
-                         One of the properties: ACTIVE, INACTIVE, or
+                         One of the properties: ACTIVE, INACTIVE, PENDING or
                          DELETED. You can set this property only to
                          ACTIVE or INACTIVE; you cannot delete a video
                          by setting its itemState to DELETED.

--- a/bc-catalog-objects/javadoc/com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html
+++ b/bc-catalog-objects/javadoc/com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html
@@ -146,6 +146,12 @@ java.lang.Object
 <BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD>
 </TR>
+<TR BGCOLOR="white" CLASS="TableRowColor">
+<TD><CODE><B><A HREF="../../../../../../com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html#PENDING">PENDING</A></B></CODE>
+
+<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD>
+</TR>
 </TABLE>
 &nbsp;
 <!-- ========== METHOD SUMMARY =========== -->
@@ -229,6 +235,15 @@ public static final <A HREF="../../../../../../com/brightcove/commons/catalog/ob
 DELETED</H3>
 <PRE>
 public static final <A HREF="../../../../../../com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html" title="enum in com.brightcove.commons.catalog.objects.enumerations">ItemStateEnum</A> <B>DELETED</B></PRE>
+<DL>
+<DL>
+</DL>
+</DL>
+
+<A NAME="PENDING"><!-- --></A><H3>
+PENDING</H3>
+<PRE>
+public static final <A HREF="../../../../../../com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html" title="enum in com.brightcove.commons.catalog.objects.enumerations">ItemStateEnum</A> <B>PENDING</B></PRE>
 <DL>
 <DL>
 </DL>

--- a/bc-catalog-objects/src/com/brightcove/commons/catalog/objects/Video.java
+++ b/bc-catalog-objects/src/com/brightcove/commons/catalog/objects/Video.java
@@ -325,6 +325,9 @@ public class Video {
 						if(ItemStateEnum.INACTIVE.toString().equals(nodeValue)){
 							itemState = ItemStateEnum.INACTIVE;
 						}
+						if(ItemStateEnum.PENDING.toString().equals(nodeValue)){
+							itemState = ItemStateEnum.PENDING;
+						}
 					}
 				}
 				else if(nodeName.equals("tags")){
@@ -459,8 +462,11 @@ public class Video {
 				else if(rootValue.toString().equals("INACTIVE")){
 					itemState = ItemStateEnum.INACTIVE;
 				}
+				else if(rootValue.toString().equals("PENDING")){
+					itemState = ItemStateEnum.PENDING;
+				}
 				else{
-					throw new JSONException("[ERR] Media API specified invalid value for item state '" + rootValue + "'.  Acceptable values are 'ACTIVE', 'DELETED' and 'INACTIVE'.");
+					throw new JSONException("[ERR] Media API specified invalid value for item state '" + rootValue + "'.  Acceptable values are 'ACTIVE', 'DELETED', 'PENDING' and 'INACTIVE'.");
 				}
 			}
 			else if("geoFilterExclude".equals(rootKey)){
@@ -1319,7 +1325,7 @@ public class Video {
 	 *          Read only?:    no<br/>
 	 *          Description:   An
 	 *                         <a href="http://docs.brightcove.com/en/media/index.html#ItemStateEnum">ItemStateEnum</a>.
-	 *                         One of the properties: ACTIVE, INACTIVE, or
+	 *                         One of the properties: ACTIVE, INACTIVE, PENDING, or
 	 *                         DELETED. You can set this property only to
 	 *                         ACTIVE or INACTIVE; you cannot delete a video
 	 *                         by setting its itemState to DELETED.
@@ -1344,7 +1350,7 @@ public class Video {
 	 *          Read only?:    no<br/>
 	 *          Description:   An
 	 *                         <a href="http://docs.brightcove.com/en/media/index.html#ItemStateEnum">ItemStateEnum</a>.
-	 *                         One of the properties: ACTIVE, INACTIVE, or
+	 *                         One of the properties: ACTIVE, INACTIVE, PENDING, or
 	 *                         DELETED. You can set this property only to
 	 *                         ACTIVE or INACTIVE; you cannot delete a video
 	 *                         by setting its itemState to DELETED.

--- a/bc-catalog-objects/src/com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.java
+++ b/bc-catalog-objects/src/com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.java
@@ -14,5 +14,5 @@ package com.brightcove.commons.catalog.objects.enumerations;
  *
  */
 public enum ItemStateEnum {
-	ACTIVE, INACTIVE, DELETED
+	ACTIVE, INACTIVE, DELETED, PENDING
 }

--- a/release-build/javadoc/com/brightcove/commons/catalog/objects/Video.html
+++ b/release-build/javadoc/com/brightcove/commons/catalog/objects/Video.html
@@ -1694,7 +1694,7 @@ public <A HREF="../../../../../com/brightcove/commons/catalog/objects/enumeratio
           Read only?:    no<br/>
           Description:   An
                          <a href="http://docs.brightcove.com/en/media/index.html#ItemStateEnum">ItemStateEnum</a>.
-                         One of the properties: ACTIVE, INACTIVE, or
+                         One of the properties: ACTIVE, INACTIVE, PENDING, or
                          DELETED. You can set this property only to
                          ACTIVE or INACTIVE; you cannot delete a video
                          by setting its itemState to DELETED.
@@ -1724,7 +1724,7 @@ public void <B>setItemState</B>(<A HREF="../../../../../com/brightcove/commons/c
           Read only?:    no<br/>
           Description:   An
                          <a href="http://docs.brightcove.com/en/media/index.html#ItemStateEnum">ItemStateEnum</a>.
-                         One of the properties: ACTIVE, INACTIVE, or
+                         One of the properties: ACTIVE, INACTIVE, PENDING, or
                          DELETED. You can set this property only to
                          ACTIVE or INACTIVE; you cannot delete a video
                          by setting its itemState to DELETED.

--- a/release-build/javadoc/com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html
+++ b/release-build/javadoc/com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html
@@ -146,6 +146,12 @@ java.lang.Object
 <BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD>
 </TR>
+<TR BGCOLOR="white" CLASS="TableRowColor">
+<TD><CODE><B><A HREF="../../../../../../com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html#PENDING">PENDING</A></B></CODE>
+
+<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</TD>
+</TR>
 </TABLE>
 &nbsp;
 <!-- ========== METHOD SUMMARY =========== -->
@@ -229,6 +235,15 @@ public static final <A HREF="../../../../../../com/brightcove/commons/catalog/ob
 DELETED</H3>
 <PRE>
 public static final <A HREF="../../../../../../com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html" title="enum in com.brightcove.commons.catalog.objects.enumerations">ItemStateEnum</A> <B>DELETED</B></PRE>
+<DL>
+<DL>
+</DL>
+</DL>
+
+<A NAME="PENDING"><!-- --></A><H3>
+PENDING</H3>
+<PRE>
+public static final <A HREF="../../../../../../com/brightcove/commons/catalog/objects/enumerations/ItemStateEnum.html" title="enum in com.brightcove.commons.catalog.objects.enumerations">ItemStateEnum</A> <B>PENDING</B></PRE>
 <DL>
 <DL>
 </DL>


### PR DESCRIPTION
We at the Toronto Star (thestar.com) are using the Brightcove OS library to pull in modified videos from Brightcove. We found an issue where once in a while, a video status equal to 'PENDING' comes in from brightcove, an exception is thrown inside video.java (as it is only checking for "ACTIVE", "INACTIVE" or "DELETED"). When this happens, we are not able to put in  the modified videos inside our CMS and thus causing a complete lockdown. We found out that when we delete that video with 'PENDING' status inside brightcove, the json request starts to work without any issues. 

We have seen this issue being raised on Google searches so we added an extra check to check for the 'PENDING' status when video list is created inside video.java
